### PR TITLE
Video Prototipo 03

### DIFF
--- a/justicia_digital/app.py
+++ b/justicia_digital/app.py
@@ -13,7 +13,7 @@ def start():
         "layouts/start.jinja2",
         title="Justicia Digital",
         message="Bienvenido a la nueva generación de sistemas de información del PJECZ.",
-        video="https://www.youtube.com/embed/H8cT17l38Eo",
+        video="https://www.youtube.com/embed/LRG-0qOdQSA",
     )
 
 


### PR DESCRIPTION
Para tener una mejor calidad de imagen, cambie el formato a MP4 en el video entregado a YouTube.